### PR TITLE
#12 Upgrade to .NET Core 3.0

### DIFF
--- a/HMBasic/inference.fsproj
+++ b/HMBasic/inference.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HMBasic.fs" />

--- a/HMMutable-RowPolymorphism/inference.fsproj
+++ b/HMMutable-RowPolymorphism/inference.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HMMutableRowPolymorphism.fs" />

--- a/HMMutable/inference.fsproj
+++ b/HMMutable/inference.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HMMutable.fs" />

--- a/HMPure-Rowpolymorphism/inference.fsproj
+++ b/HMPure-Rowpolymorphism/inference.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HMPureRowpolymorphism.fs" />

--- a/HMPure/inference.fsproj
+++ b/HMPure/inference.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HMPure.fs" />

--- a/HMSplitSolve/inference.fsproj
+++ b/HMSplitSolve/inference.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HMSplitSolve.fs" />


### PR DESCRIPTION
Per https://github.com/7sharp9/write-you-an-inference-in-fsharp/issues/12

This change is pretty self-explanatory: I just changed each of the six projects to target .NET Core 3.0, instead of .NET Core 2.0.